### PR TITLE
make l10n_us_administrative work with 9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# dotfiles
+.*
+!.gitignore
+# compiled python files
+*.py[co]
+# emacs backup files
+*~

--- a/l10n_us_administrative/view/res_partner.xml
+++ b/l10n_us_administrative/view/res_partner.xml
@@ -8,7 +8,8 @@
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="arch" type="xml">
                 <field name="country_id" position="before">
-                    <field name="county_id" placeholder="County" options='{"no_open": True}' domain="[('state_id','=',state_id)]" attrs="{'readonly': [('use_parent_address','=',True)]}"/>
+                    <field name="county_id" placeholder="County" class="o_address_country" options='{"no_open": True}' domain="[('state_id','=',state_id)]"
+                        attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                 </field>  
             </field>
         </record>


### PR DESCRIPTION
The attrs attribute for the County field was causing an error message: Unknown field in domain.  Apparently, field use_parent_address isn't accessible anymore.

I changed the attrs to match all the other address fields in 9.0.

I also added a class attribute to get the field to show in Chrome.

p.s. I added a .gitignore file.